### PR TITLE
Pass additional options to underlying Typhoeus client

### DIFF
--- a/lib/api_client.rb
+++ b/lib/api_client.rb
@@ -97,7 +97,7 @@ module AmzSpApi
       # set ssl_verifyhosts option based on @config.verify_ssl_host (true/false)
       _verify_ssl_host = @config.verify_ssl_host ? 2 : 0
 
-      req_opts = {
+      req_opts = (@config.request_extra_opts || {}).merge({
         :method => http_method,
         :headers => header_params,
         :params => query_params,
@@ -108,7 +108,7 @@ module AmzSpApi
         :sslcert => @config.cert_file,
         :sslkey => @config.key_file,
         :verbose => @config.debugging
-      }
+      })
 
       # set custom cert, if provided
       req_opts[:cainfo] = @config.ssl_ca_cert if @config.ssl_ca_cert

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -113,6 +113,13 @@ module AmzSpApi
     # Client private key file (for client certificate)
     attr_accessor :key_file
 
+    ### Typhoeus request extra options
+    # Additional options to pass to Typhoeus::Request.new(url, opts)
+    #
+    # @see {http://rubydoc.info/github/typhoeus/ethon/Ethon/Easy/Options Ethon::Easy::Options} for more options.
+    # @return [Hash] Additional options
+    attr_accessor :request_extra_opts
+
     # Set this to customize parameters encoding of array parameter with multi collectionFormat.
     # Default to nil.
     #
@@ -137,6 +144,7 @@ module AmzSpApi
       @params_encoding = nil
       @cert_file = nil
       @key_file = nil
+      @request_extra_opts = {}
       @debugging = false
       @inject_format = false
       @force_ending_format = false


### PR DESCRIPTION
My particular need was to use custom `proxy` option, but there are various other low-level options one may need to pass. This minor change allows passing custom request options straight to underlying Typhoeus client. You may then use it in the code like this:
```ruby
config = AmzSpApi::SpConfiguration.new
config.request_extra_opts = {
  proxy: "http://user:pass@host:port",
  ...
}
...
client = AmzSpApi::SpApiClient.new(config)
```