### PR TITLE
Fixes compatibility with older versions of Rails

### DIFF
--- a/amz_sp_api.gemspec
+++ b/amz_sp_api.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 1.9"
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
-  s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
+  s.add_runtime_dependency 'json'
   s.add_runtime_dependency 'aws-sigv4', '~> 1.2'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'


### PR DESCRIPTION
Verified that this library works with JSON Gem v1.* (working on a legacy Rails project 3.23)